### PR TITLE
Remove attributes which obsolete.

### DIFF
--- a/src/Resources/contao/templates/mod_doccheck_login.html5
+++ b/src/Resources/contao/templates/mod_doccheck_login.html5
@@ -2,9 +2,6 @@
 
 <?php $this->block('content') ?>
 <iframe
-    align="left"
-    frameborder="0"
-    scrolling="no"
     width="467"
     height="231"
     name="dc_login_iframe"


### PR DESCRIPTION
W3C Validator says: Error: The `scrolling`, `align ` etc . attributes within iframe element are obsolete. Use CSS instead.